### PR TITLE
Remove the dependency to reactive-streams-junit5-tck

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,10 +52,15 @@
 
     <properties>
         <reactive-streams.version>1.0.3</reactive-streams.version>
+
         <mutiny.version>1.4.0</mutiny.version>
         <awaitility.version>4.2.0</awaitility.version>
-        <junit-jupiter.version>5.8.2</junit-jupiter.version>
         <assertj-core.version>3.22.0</assertj-core.version>
+
+        <junit-jupiter.version>5.8.2</junit-jupiter.version>
+        <testng.version>7.5</testng.version>
+        <testng-junit5-engine.version>1.0.1</testng-junit5-engine.version>
+        <logback-classic.version>1.2.7</logback-classic.version>
 
         <jbang-maven-plugin.version>0.0.7</jbang-maven-plugin.version>
         <build-helper-maven-plugin.version>3.3.0</build-helper-maven-plugin.version>
@@ -85,19 +90,25 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>io.smallrye.reactive</groupId>
-            <artifactId>reactive-streams-junit5-tck</artifactId>
-            <version>${mutiny.version}</version>
-            <classifier>tests</classifier>
-            <type>test-jar</type>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.reactivestreams</groupId>
             <artifactId>reactive-streams-tck</artifactId>
             <version>${reactive-streams.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>${assertj-core.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>${awaitility.version}</version>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
@@ -111,17 +122,23 @@
             <version>${junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- TestNG running in JUnit5 -->
         <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <version>${assertj-core.version}</version>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>${testng.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.awaitility</groupId>
-            <artifactId>awaitility</artifactId>
-            <version>${awaitility.version}</version>
+            <groupId>org.junit.support</groupId>
+            <artifactId>testng-engine</artifactId>
+            <version>${testng-junit5-engine.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback-classic.version}</version>
         </dependency>
     </dependencies>
 

--- a/src/test/java/mutiny/zero/tck/BufferringTubePublisherTckTest.java
+++ b/src/test/java/mutiny/zero/tck/BufferringTubePublisherTckTest.java
@@ -1,8 +1,8 @@
 package mutiny.zero.tck;
 
 import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.PublisherVerification;
 import org.reactivestreams.tck.TestEnvironment;
-import org.reactivestreams.tck.junit5.PublisherVerification;
 
 import mutiny.zero.BackpressureStrategy;
 import mutiny.zero.TubeConfiguration;

--- a/src/test/java/mutiny/zero/tck/CompletionStageTckPublisherTest.java
+++ b/src/test/java/mutiny/zero/tck/CompletionStageTckPublisherTest.java
@@ -4,8 +4,8 @@ import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
 
 import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.PublisherVerification;
 import org.reactivestreams.tck.TestEnvironment;
-import org.reactivestreams.tck.junit5.PublisherVerification;
 
 import mutiny.zero.ZeroPublisher;
 

--- a/src/test/java/mutiny/zero/tck/DroppingTubePublisherTckTest.java
+++ b/src/test/java/mutiny/zero/tck/DroppingTubePublisherTckTest.java
@@ -1,8 +1,8 @@
 package mutiny.zero.tck;
 
 import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.PublisherVerification;
 import org.reactivestreams.tck.TestEnvironment;
-import org.reactivestreams.tck.junit5.PublisherVerification;
 
 import mutiny.zero.BackpressureStrategy;
 import mutiny.zero.TubeConfiguration;

--- a/src/test/java/mutiny/zero/tck/EmptyPublisherTckTest.java
+++ b/src/test/java/mutiny/zero/tck/EmptyPublisherTckTest.java
@@ -1,8 +1,8 @@
 package mutiny.zero.tck;
 
 import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.PublisherVerification;
 import org.reactivestreams.tck.TestEnvironment;
-import org.reactivestreams.tck.junit5.PublisherVerification;
 
 import mutiny.zero.ZeroPublisher;
 

--- a/src/test/java/mutiny/zero/tck/ErrorTubePublisherTckTest.java
+++ b/src/test/java/mutiny/zero/tck/ErrorTubePublisherTckTest.java
@@ -1,8 +1,8 @@
 package mutiny.zero.tck;
 
 import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.PublisherVerification;
 import org.reactivestreams.tck.TestEnvironment;
-import org.reactivestreams.tck.junit5.PublisherVerification;
 
 import mutiny.zero.BackpressureStrategy;
 import mutiny.zero.TubeConfiguration;

--- a/src/test/java/mutiny/zero/tck/FailurePublisherTckTest.java
+++ b/src/test/java/mutiny/zero/tck/FailurePublisherTckTest.java
@@ -4,8 +4,8 @@ import java.io.IOException;
 import java.util.stream.LongStream;
 
 import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.PublisherVerification;
 import org.reactivestreams.tck.TestEnvironment;
-import org.reactivestreams.tck.junit5.PublisherVerification;
 
 import mutiny.zero.ZeroPublisher;
 

--- a/src/test/java/mutiny/zero/tck/GeneratorPublisherTckTest.java
+++ b/src/test/java/mutiny/zero/tck/GeneratorPublisherTckTest.java
@@ -3,8 +3,8 @@ package mutiny.zero.tck;
 import java.util.Iterator;
 
 import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.PublisherVerification;
 import org.reactivestreams.tck.TestEnvironment;
-import org.reactivestreams.tck.junit5.PublisherVerification;
 
 import mutiny.zero.ZeroPublisher;
 

--- a/src/test/java/mutiny/zero/tck/IgnoringTubePublisherTckTest.java
+++ b/src/test/java/mutiny/zero/tck/IgnoringTubePublisherTckTest.java
@@ -1,8 +1,8 @@
 package mutiny.zero.tck;
 
 import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.PublisherVerification;
 import org.reactivestreams.tck.TestEnvironment;
-import org.reactivestreams.tck.junit5.PublisherVerification;
 
 import mutiny.zero.BackpressureStrategy;
 import mutiny.zero.TubeConfiguration;

--- a/src/test/java/mutiny/zero/tck/IterablePublisherTckTest.java
+++ b/src/test/java/mutiny/zero/tck/IterablePublisherTckTest.java
@@ -3,8 +3,8 @@ package mutiny.zero.tck;
 import java.util.stream.LongStream;
 
 import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.PublisherVerification;
 import org.reactivestreams.tck.TestEnvironment;
-import org.reactivestreams.tck.junit5.PublisherVerification;
 
 import mutiny.zero.ZeroPublisher;
 

--- a/src/test/java/mutiny/zero/tck/LatestTubePublisherTckTest.java
+++ b/src/test/java/mutiny/zero/tck/LatestTubePublisherTckTest.java
@@ -1,8 +1,8 @@
 package mutiny.zero.tck;
 
 import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.PublisherVerification;
 import org.reactivestreams.tck.TestEnvironment;
-import org.reactivestreams.tck.junit5.PublisherVerification;
 
 import mutiny.zero.BackpressureStrategy;
 import mutiny.zero.TubeConfiguration;

--- a/src/test/java/mutiny/zero/tck/MapHelperPublisherTckTest.java
+++ b/src/test/java/mutiny/zero/tck/MapHelperPublisherTckTest.java
@@ -3,8 +3,8 @@ package mutiny.zero.tck;
 import java.util.stream.LongStream;
 
 import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.PublisherVerification;
 import org.reactivestreams.tck.TestEnvironment;
-import org.reactivestreams.tck.junit5.PublisherVerification;
 
 import mutiny.zero.PublisherHelpers;
 import mutiny.zero.ZeroPublisher;

--- a/src/test/java/mutiny/zero/tck/StreamPublisherTckTest.java
+++ b/src/test/java/mutiny/zero/tck/StreamPublisherTckTest.java
@@ -5,8 +5,8 @@ import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
 import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.PublisherVerification;
 import org.reactivestreams.tck.TestEnvironment;
-import org.reactivestreams.tck.junit5.PublisherVerification;
 
 import mutiny.zero.ZeroPublisher;
 

--- a/src/test/java/mutiny/zero/tck/UnboundedBufferingTubePublisherTckTest.java
+++ b/src/test/java/mutiny/zero/tck/UnboundedBufferingTubePublisherTckTest.java
@@ -1,8 +1,8 @@
 package mutiny.zero.tck;
 
 import org.reactivestreams.Publisher;
+import org.reactivestreams.tck.PublisherVerification;
 import org.reactivestreams.tck.TestEnvironment;
-import org.reactivestreams.tck.junit5.PublisherVerification;
 
 import mutiny.zero.BackpressureStrategy;
 import mutiny.zero.TubeConfiguration;

--- a/src/test/resources/logback.xml
+++ b/src/test/resources/logback.xml
@@ -1,0 +1,15 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%yellow(%d) %highlight(%level) %green([%thread]) %cyan(%logger{50}) - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="org.testng.internal" level="info"/>
+
+    <root level="debug">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+</configuration>


### PR DESCRIPTION
- Use plain TestNG for the RS TCK
- Mix JUnit5 + TestNG in Jupiter
- Silence the TestNG SLF4J warning with Logback

Fixes #39
