### PR TITLE
fix(buffer-tube): eliminate lost-demand race between handleItem and request(n)

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,4 +1,4 @@
 name: SmallRye Mutiny Zero
 release:
-  current-version: 1.3.0
-  next-version: 1.3.1-SNAPSHOT
+  current-version: 1.3.1
+  next-version: 1.3.2-SNAPSHOT

--- a/mutiny-zero/src/main/java/mutiny/zero/internal/BufferingTube.java
+++ b/mutiny-zero/src/main/java/mutiny/zero/internal/BufferingTube.java
@@ -20,13 +20,12 @@ public class BufferingTube<T> extends BufferingTubeBase<T> {
 
     @Override
     protected void handleItem(T item) {
-        if (outstandingRequests() > 0L) {
-            dispatchQueue.offer(item);
-            drainLoop();
-        } else if (!overflowQueue.offer(item)) {
+        if (!overflowQueue.offer(item)) {
             fail(new IllegalStateException(
                     "The following item cannot be propagated because there is no demand and the overflow buffer is full: "
                             + item));
+            return;
         }
+        drainLoop();
     }
 }

--- a/mutiny-zero/src/main/java/mutiny/zero/internal/BufferingTubeBase.java
+++ b/mutiny-zero/src/main/java/mutiny/zero/internal/BufferingTubeBase.java
@@ -5,7 +5,7 @@ import java.util.concurrent.Flow;
 
 public abstract class BufferingTubeBase<T> extends TubeBase<T> {
 
-    protected boolean delayedComplete = false;
+    protected volatile boolean delayedComplete = false;
 
     public BufferingTubeBase(Flow.Subscriber<? super T> subscriber) {
         super(subscriber);
@@ -23,23 +23,28 @@ public abstract class BufferingTubeBase<T> extends TubeBase<T> {
         } else {
             Helper.add(requested, n);
             requestConsumer.accept(n);
-
-            long remaining = n;
-            T bufferedItem;
-            do {
-                bufferedItem = overflowQueue().poll();
-                if (bufferedItem != null) {
-                    dispatchQueue.offer(bufferedItem);
-                    remaining--;
-                }
-            } while (bufferedItem != null && remaining > 0L);
-
-            if (!completed) {
-                completed = delayedComplete && overflowQueue().isEmpty();
-            }
         }
-
         drainLoop();
+    }
+
+    @Override
+    protected void drainOverflow() {
+        long remaining = outstandingRequests();
+        if (remaining <= 0L) {
+            return;
+        }
+        T bufferedItem;
+        do {
+            bufferedItem = overflowQueue().poll();
+            if (bufferedItem != null) {
+                dispatchQueue.offer(bufferedItem);
+                remaining--;
+            }
+        } while (bufferedItem != null && remaining > 0L);
+
+        if (!completed && delayedComplete && overflowQueue().isEmpty()) {
+            completed = true;
+        }
     }
 
     @Override

--- a/mutiny-zero/src/main/java/mutiny/zero/internal/TubeBase.java
+++ b/mutiny-zero/src/main/java/mutiny/zero/internal/TubeBase.java
@@ -151,6 +151,10 @@ public abstract class TubeBase<T> implements Tube<T>, Subscription {
 
     protected abstract void handleItem(T item);
 
+    protected void drainOverflow() {
+        // no-op; overridden by buffering tubes to transfer overflow → dispatchQueue
+    }
+
     protected void drainLoop() {
         if (wip.getAndIncrement() != 0) {
             // Another tread is working
@@ -160,6 +164,7 @@ public abstract class TubeBase<T> implements Tube<T>, Subscription {
         int missed = 1;
         Queue<T> queue = dispatchQueue;
         while (missed != 0) {
+            drainOverflow();
             long emitted = 0L;
             long pending = outstandingRequests();
 

--- a/mutiny-zero/src/main/java/mutiny/zero/internal/UnbounbedBufferingTube.java
+++ b/mutiny-zero/src/main/java/mutiny/zero/internal/UnbounbedBufferingTube.java
@@ -20,11 +20,7 @@ public class UnbounbedBufferingTube<T> extends BufferingTubeBase<T> {
 
     @Override
     protected void handleItem(T item) {
-        if (outstandingRequests() > 0L) {
-            dispatchQueue.offer(item);
-            drainLoop();
-        } else {
-            overflowQueue.offer(item);
-        }
+        overflowQueue.offer(item);
+        drainLoop();
     }
 }

--- a/mutiny-zero/src/test/java/mutiny/zero/ZeroPublisherTest.java
+++ b/mutiny-zero/src/test/java/mutiny/zero/ZeroPublisherTest.java
@@ -940,6 +940,38 @@ class ZeroPublisherTest {
             sub.awaitCompletion(Duration.ofSeconds(5));
             sub.assertCompleted().assertItems(1);
         }
+
+        @RepeatedTest(10)
+        @DisplayName("BUFFER tube: demand not lost when request(1) races with concurrent multi-item producer")
+        void demandNotLostUnderConcurrentProducerAndBoundedRequest() throws Exception {
+            CyclicBarrier barrier = new CyclicBarrier(2);
+            AssertSubscriber<Integer> sub = AssertSubscriber.create();
+            TubeConfiguration configuration = new TubeConfiguration()
+                    .withBackpressureStrategy(BackpressureStrategy.BUFFER)
+                    .withBufferSize(256);
+            ZeroPublisher.<Integer> create(configuration, tube -> {
+                new Thread(() -> {
+                    try {
+                        for (int i = 0; i < 3; i++) {
+                            barrier.await(5, TimeUnit.SECONDS);
+                            tube.send(i);
+                        }
+                        tube.complete();
+                    } catch (Exception e) {
+                        Thread.currentThread().interrupt();
+                    }
+                }).start();
+            }).subscribe(sub);
+
+            for (int i = 0; i < 3; i++) {
+                final int expected = i;
+                barrier.await(5, TimeUnit.SECONDS);
+                sub.request(1);
+                await().atMost(Duration.ofSeconds(5)).until(() -> sub.getItems().size() > expected);
+            }
+            sub.awaitCompletion(Duration.ofSeconds(5));
+            sub.assertCompleted().assertItems(0, 1, 2);
+        }
     }
 
     @Nested

--- a/mutiny-zero/src/test/java/mutiny/zero/tck/BufferingTubePublisherTckTest.java
+++ b/mutiny-zero/src/test/java/mutiny/zero/tck/BufferingTubePublisherTckTest.java
@@ -9,9 +9,9 @@ import mutiny.zero.BackpressureStrategy;
 import mutiny.zero.TubeConfiguration;
 import mutiny.zero.ZeroPublisher;
 
-public class BufferringTubePublisherTckTest extends FlowPublisherVerification<Long> {
+public class BufferingTubePublisherTckTest extends FlowPublisherVerification<Long> {
 
-    public BufferringTubePublisherTckTest() {
+    public BufferingTubePublisherTckTest() {
         super(new TestEnvironment());
     }
 


### PR DESCRIPTION
Fixes: #365